### PR TITLE
Update Homebrew formula to 1.0.0.rc.1

### DIFF
--- a/Formula/toucan.rb
+++ b/Formula/toucan.rb
@@ -1,0 +1,25 @@
+class Toucan < Formula
+  desc "Toucan is a static site generator written in Swift."
+  homepage "https://github.com/GErP83/my-toucan"
+  version "1.0.0.rc.1"
+
+  if OS.mac?
+    url "https://github.com/GErP83/my-toucan/releases/download/1.0.0-rc.1/toucan-macos-1.0.0.rc.1.zip"
+    sha256 "2c0903bb226812076d2e8eaa4076d478b3e147fa5bfcef47d9358fefb2f2eff0"
+  elsif OS.linux?
+    url "https://github.com/GErP83/my-toucan/releases/download/1.0.0-rc.1/toucan-linux-1.0.0.rc.1.zip"
+    sha256 "c1ac9b0f60887dae1707d1b15d548a04d2bfbcc0dc8163eedd254a448fef5a3e"
+  end
+
+  def install
+    bin.install "toucan"
+    bin.install "toucan-init"
+    bin.install "toucan-generate"
+    bin.install "toucan-serve"
+    bin.install "toucan-watch"
+  end
+
+  test do
+    assert_match "Usage", shell_output("\#{bin}/toucan --help")
+  end
+end


### PR DESCRIPTION
This PR updates the Homebrew formula to version `1.0.0.rc.1`.